### PR TITLE
Setting up a SuperProject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,6 @@ project('LATfield2','cpp','c',
         default_options : ['cpp_std=c++17',
         'warning_level=3'],
         version: '1.1')
-add_global_arguments(['-Ofast','-march=native' ],language : 'cpp')
 
 cpp=meson.get_compiler('cpp')
 mpi=dependency('mpi',language: 'cpp')

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('LATfield2','cpp','c',
         default_options : ['cpp_std=c++17',
-        'warning_level=3'],
+        'warning_level=3',
+        'optimization=3'],
         version: '1.1')
 
 cpp=meson.get_compiler('cpp')
@@ -53,3 +54,5 @@ subdir('benchmarks_tests')
 subdir('examples')
 
 subdir('tests')
+
+liblatfield_dep = declare_dependency(include_directories: include, link_with: liblatfield)


### PR DESCRIPTION
I am preparing a super-project repository that can be used to compile LATfield2, gevolution and Gadget4, without the need to build them all separately. First, it is possible that we need to make some changes to the meson files in the sub-projects.